### PR TITLE
Ensure unique filenames for uploaded media

### DIFF
--- a/activities/models.py
+++ b/activities/models.py
@@ -5,6 +5,7 @@ from django.utils.text import slugify
 from committees.models import Committee
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
+from utils.upload_paths import hashed_upload_path
 
 def start_date_not_in_past(date):
     if date < timezone.now():
@@ -25,7 +26,7 @@ class Activity(models.Model):
     start = models.DateTimeField(_('start date'), validators=[start_date_not_in_past])
     end = models.DateTimeField(_('end date'))
     location = models.CharField(_('location'), max_length=200)
-    poster = models.ImageField(upload_to='activities/posters/%Y/%m/%d/', blank=True, null=True)
+    poster = models.ImageField(upload_to=hashed_upload_path('activities/posters'), blank=True, null=True)
     committee = models.ForeignKey(Committee, on_delete=models.CASCADE, related_name='activities', verbose_name=_('committee'))
     created_at = models.DateTimeField(_('created at'), default=timezone.now)
     updated_at = models.DateTimeField(_('updated at'), auto_now=True)

--- a/news/models.py
+++ b/news/models.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 from django.utils.text import slugify
 from committees.models import Committee
 from django.utils.translation import gettext_lazy as _
+from utils.upload_paths import hashed_upload_path
 
 class Post(models.Model):
     class Meta:
@@ -14,8 +15,8 @@ class Post(models.Model):
     title = models.CharField(_('title'), max_length=200)
     slug = models.SlugField(max_length=200, unique=True)
     content = models.TextField(_('content'))
-    poster = models.ImageField(upload_to='news/posters/%Y/%m/%d/', blank=True, null=True)
-    attachment = models.FileField(_('attachment'), upload_to='news/attachments/%Y/%m/%d/', blank=True, null=True)
+    poster = models.ImageField(upload_to=hashed_upload_path('news/posters'), blank=True, null=True)
+    attachment = models.FileField(_('attachment'), upload_to=hashed_upload_path('news/attachments'), blank=True, null=True)
     committee = models.ForeignKey(Committee, on_delete=models.CASCADE, related_name='news', verbose_name=_('committee'))
     created_at = models.DateTimeField(_('created at'), default=timezone.now)
     updated_at = models.DateTimeField(_('updated at'), auto_now=True)

--- a/utils/upload_paths.py
+++ b/utils/upload_paths.py
@@ -1,0 +1,39 @@
+"""Utilities for generating unique upload paths for media files."""
+
+from __future__ import annotations
+
+import os
+import uuid
+from typing import Callable
+
+from django.utils import timezone
+
+
+def hashed_upload_path(prefix: str) -> Callable[[object, str], str]:
+    """Return a callable for ``upload_to`` that adds a unique hash to filenames.
+
+    The resulting path has the form ``"{prefix}/YYYY/MM/DD/<name>_<hash><ext>"``
+    where ``<hash>`` is a random hexadecimal string ensuring uniqueness.
+
+    Parameters
+    ----------
+    prefix:
+        Directory prefix where the file should be stored (e.g. ``"news/posters"``).
+
+    Returns
+    -------
+    Callable[[object, str], str]
+        Function suitable for Django's ``upload_to`` argument.
+    """
+
+    def uploader(instance: object, filename: str) -> str:
+        # Determine date path based on ``created_at`` if available, otherwise now.
+        created = getattr(instance, "created_at", None) or timezone.now()
+        date_path = created.strftime("%Y/%m/%d")
+
+        base, ext = os.path.splitext(filename)
+        file_hash = uuid.uuid4().hex
+        return f"{prefix}/{date_path}/{base}_{file_hash}{ext}"
+
+    return uploader
+


### PR DESCRIPTION
## Summary
- Generate hashed upload paths for activity and news media
- Use shared utility to create dated directories with unique filenames

## Testing
- `SECRET_KEY=test python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6896055676ac832f91a8155cfa5388f7