### PR TITLE
Add CI workflow for linting and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install flake8
+      - name: Lint
+        run: flake8 .
+      - name: Run tests
+        env:
+          SECRET_KEY: test
+        run: python manage.py test


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to lint with flake8 and run tests on pull requests

## Testing
- `python manage.py test`
- `pip install flake8` *(fails: 403 Forbidden)*
- `flake8 .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68970ebb0200832fb453f43f27449474