### PR TITLE
Remove unused imports flagged by flake8

### DIFF
--- a/activities/tests/test_views.py
+++ b/activities/tests/test_views.py
@@ -1,10 +1,11 @@
-from django.test import TestCase, Client
+from django.test import TestCase
 from django.urls import reverse
 from django.contrib.auth.models import User, Group
 from committees.models import Committee
 from activities.models import Activity
 import datetime
 from django.utils import timezone
+
 
 class ActivitiesIndexViewTest(TestCase):
     def setUp(self):

--- a/config/tests/test_urls.py
+++ b/config/tests/test_urls.py
@@ -1,9 +1,9 @@
 from django.test import TestCase, Client
 from django.urls import reverse, resolve
-from news.views import HomePageView, IndexView as NewsIndexView, DetailView as NewsDetailView
-from activities.views import IndexView as ActivitiesIndexView, DetailView as ActivitiesDetailView
-from committees.views import IndexView as CommitteesIndexView, DetailView as CommitteesDetailView
-from django.contrib.admin.sites import AdminSite
+from news.views import HomePageView, IndexView as NewsIndexView
+from activities.views import IndexView as ActivitiesIndexView
+from committees.views import IndexView as CommitteesIndexView
+
 
 class URLConfigTest(TestCase):
     """Tests for the main URL configuration."""

--- a/config/tests/test_wsgi.py
+++ b/config/tests/test_wsgi.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 import os
-import importlib.util
 from config.wsgi import application
+
 
 class WSGITest(TestCase):
     """Tests for the WSGI configuration."""

--- a/news/tests/test_views.py
+++ b/news/tests/test_views.py
@@ -1,10 +1,11 @@
-from django.test import TestCase, Client
+from django.test import TestCase
 from django.urls import reverse
 from django.contrib.auth.models import User, Group
 from committees.models import Committee
 from news.models import Post
 import datetime
 from django.utils import timezone
+
 
 class NewsIndexViewTest(TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- prune unused imports in test modules
- ensure test modules start with a blank line after imports for flake8 compliance

## Testing
- `flake8 --select=E,F --ignore=E501 activities/tests/test_views.py config/tests/test_urls.py config/tests/test_wsgi.py news/tests/test_views.py`
- `SECRET_KEY=testing python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689723ef2d78832fba0320f179dfba79