### PR TITLE
Add Redis-based caching with django-redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,19 @@ created automatically when the project starts.
 Logging statements are present in the news, activities, and committees apps to
 trace data retrieval and filtering operations, aiding debugging and observability.
 
+### Caching
+
+The project uses [Redis](https://redis.io/) for caching via
+[django-redis](https://github.com/jazzband/django-redis).
+By default, it connects to a local Redis instance at `redis://127.0.0.1:6379/1`.
+
+To use Azure Cache for Redis, set the `REDIS_URL` environment variable to the
+connection string provided by Azure. For example:
+
+```bash
+export REDIS_URL=rediss://:<password>@<hostname>:<port>/0
+```
+
 ### Committees and User Groups
 This application uses Django's built-in Groups functionality to manage committees:
 - Each committee is represented as a Django Group

--- a/config/settings.py
+++ b/config/settings.py
@@ -126,6 +126,20 @@ DATABASES = {
 }
 
 
+# Caching
+# https://docs.djangoproject.com/en/5.2/topics/cache/#redis
+CACHES = {
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": os.getenv("REDIS_URL", "redis://127.0.0.1:6379/1"),
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            "IGNORE_EXCEPTIONS": True,
+        },
+    }
+}
+
+
 # Password validation
 # https://docs.djangoproject.com/en/5.2/ref/settings/#auth-password-validators
 

--- a/config/tests/test_settings.py
+++ b/config/tests/test_settings.py
@@ -56,3 +56,12 @@ class SettingsTest(TestCase):
         self.assertEqual(settings.X_FRAME_OPTIONS, "DENY")
         self.assertGreaterEqual(settings.SECURE_HSTS_SECONDS, 0)
         self.assertIsInstance(settings.CSRF_TRUSTED_ORIGINS, list)
+
+    def test_cache_configuration(self):
+        """Test that Redis caching is configured with a sensible default."""
+        cache_config = settings.CACHES["default"]
+        self.assertEqual(cache_config["BACKEND"], "django_redis.cache.RedisCache")
+        self.assertEqual(
+            cache_config["LOCATION"],
+            os.getenv("REDIS_URL", "redis://127.0.0.1:6379/1"),
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Django==5.2.5
 pillow==11.3.0
 python-dotenv==1.1.1
 sqlparse==0.5.3
+django-redis==5.4.0


### PR DESCRIPTION
## Summary
- add django-redis dependency
- configure Redis cache backend with env var override for Azure
- document caching configuration and test settings

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689750d95ae4832f8582f2858f784e5f