### PR TITLE
Add missing docstrings across apps

### DIFF
--- a/activities/admin.py
+++ b/activities/admin.py
@@ -1,3 +1,5 @@
+"""Admin configuration for the activities application."""
+
 from django.contrib import admin
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
@@ -6,6 +8,8 @@ from .models import Activity
 
 
 class ActivityAdmin(admin.ModelAdmin):
+    """Admin interface definition for :class:`~activities.models.Activity`."""
+
     list_display = ("title", "location", "start", "end")
     list_filter = ("start", "end")
     search_fields = ("title", "content", "location")
@@ -17,6 +21,7 @@ class ActivityAdmin(admin.ModelAdmin):
     ]
 
     def clean(self):
+        """Validate that the end date is not before the start date."""
         cleaned_data = super().clean()
         start = cleaned_data.get("start")
         end = cleaned_data.get("end")

--- a/activities/apps.py
+++ b/activities/apps.py
@@ -1,8 +1,12 @@
+"""Configuration for the activities application."""
+
 from django.apps import AppConfig
 from django.utils.translation import gettext_lazy as _
 
 
 class ActivitiesConfig(AppConfig):
+    """Application configuration for the activities app."""
+
     default_auto_field = "django.db.models.BigAutoField"
     name = "activities"
     verbose_name = _("Activities")

--- a/activities/models.py
+++ b/activities/models.py
@@ -1,3 +1,5 @@
+"""Database models for the activities application."""
+
 from django.db import models
 from django.utils import timezone
 from django.urls import reverse
@@ -9,6 +11,7 @@ from utils.upload_paths import hashed_upload_path
 
 
 def start_date_not_in_past(date):
+    """Ensure the provided date is not in the past."""
     if date < timezone.now():
         raise ValidationError(
             _("Start date: %(date)s cannot be in the past") % {"date": date},
@@ -17,7 +20,11 @@ def start_date_not_in_past(date):
 
 
 class Activity(models.Model):
+    """Model representing an activity organised by a committee."""
+
     class Meta:
+        """Metadata for the :class:`Activity` model."""
+
         verbose_name = _("Activity")
         verbose_name_plural = _("Activities")
         ordering = ["start"]
@@ -41,12 +48,15 @@ class Activity(models.Model):
     updated_at = models.DateTimeField(_("updated at"), auto_now=True)
 
     def save(self, *args, **kwargs):
+        """Generate a slug from the title on first save."""
         if not self.slug:
             self.slug = slugify(self.title)
         super().save(*args, **kwargs)
 
     def get_absolute_url(self):
+        """Return the URL for the activity detail page."""
         return reverse("activities:detail", args=[self.slug])
 
     def __str__(self):
+        """Return the string representation of the activity."""
         return self.title

--- a/activities/urls.py
+++ b/activities/urls.py
@@ -1,3 +1,5 @@
+"""URL configuration for the activities application."""
+
 from django.urls import path
 
 from . import views

--- a/activities/views.py
+++ b/activities/views.py
@@ -1,3 +1,5 @@
+"""Views for the activities application."""
+
 import logging
 from django.views.generic import ListView, DetailView, base
 
@@ -8,24 +10,32 @@ logger = logging.getLogger(__name__)
 
 
 class IndexView(ListView):
+    """Display a list of upcoming activities."""
+
     template_name = "activities/index.html"
     context_object_name = "upcoming_activity_list"
 
     def get_queryset(self):
+        """Return the next five upcoming activities."""
         logger.debug("Fetching upcoming activities for index view")
         return Activity.objects.all()[:5]
 
 
 class DetailView(DetailView):
+    """Display the details of a single activity."""
+
     model = Activity
     template_name = "activities/detail.html"
 
 
 class ActivitiesArchiveView(base.TemplateView):
+    """Render an archive of activities grouped by date."""
+
     template_name = "activities/archive.html"
     context_object_name = "grouped_activities"
 
     def get_queryset(self):
+        """Return activities optionally filtered by committee slug."""
         # Filter activities by committee if a query parameter is provided
         queryset = Activity.objects.all()
         committee_slug = self.request.GET.get("committee")
@@ -37,6 +47,7 @@ class ActivitiesArchiveView(base.TemplateView):
         return queryset
 
     def get_context_data(self, **kwargs):
+        """Build the context with grouped activities and committees."""
         context = super().get_context_data(**kwargs)
         queryset = self.get_queryset()
 

--- a/committees/admin.py
+++ b/committees/admin.py
@@ -1,9 +1,13 @@
+"""Admin configuration for the committees application."""
+
 from django.contrib import admin
 
 from .models import Committee
 
 
 class CommitteeAdmin(admin.ModelAdmin):
+    """Admin interface definition for :class:`~committees.models.Committee`."""
+
     list_display = ("group", "email", "contact_person")
     search_fields = ("group", "email", "contact_person")
     fieldsets = [

--- a/committees/apps.py
+++ b/committees/apps.py
@@ -1,8 +1,12 @@
+"""Configuration for the committees application."""
+
 from django.apps import AppConfig
 from django.utils.translation import gettext_lazy as _
 
 
 class CommitteesConfig(AppConfig):
+    """Application configuration for the committees app."""
+
     default_auto_field = "django.db.models.BigAutoField"
     name = "committees"
     verbose_name = _("Committees")

--- a/committees/models.py
+++ b/committees/models.py
@@ -1,3 +1,5 @@
+"""Database models for the committees application."""
+
 from django.db import models
 from django.utils.text import slugify
 from django.urls import reverse
@@ -6,7 +8,11 @@ from django.utils.translation import gettext_lazy as _
 
 
 class Committee(models.Model):
+    """Model representing a committee within the community."""
+
     class Meta:
+        """Metadata for the :class:`Committee` model."""
+
         verbose_name = _("Committee")
         verbose_name_plural = _("Committees")
         ordering = ["group"]
@@ -25,12 +31,15 @@ class Committee(models.Model):
     email = models.EmailField(_("email"))
 
     def save(self, *args, **kwargs):
+        """Generate a slug from the group's name on first save."""
         if not self.slug:
             self.slug = slugify(self.group.name)
         super().save(*args, **kwargs)
 
     def get_absolute_url(self):
+        """Return the URL for the committee detail page."""
         return reverse("committees:detail", args=[self.slug])
 
     def __str__(self):
+        """Return the string representation of the committee."""
         return self.group.name

--- a/committees/urls.py
+++ b/committees/urls.py
@@ -1,3 +1,5 @@
+"""URL configuration for the committees application."""
+
 from django.urls import path
 
 from . import views

--- a/committees/views.py
+++ b/committees/views.py
@@ -1,3 +1,5 @@
+"""Views for the committees application."""
+
 import logging
 from django.views.generic import ListView, DetailView
 
@@ -7,19 +9,25 @@ logger = logging.getLogger(__name__)
 
 
 class IndexView(ListView):
+    """Display a list of committees."""
+
     template_name = "committees/index.html"
     context_object_name = "committee_list"
 
     def get_queryset(self):
+        """Return all committees ordered by group name descending."""
         logger.debug("Fetching committee list ordered by group")
         return Committee.objects.order_by("-group")
 
 
 class DetailView(DetailView):
+    """Display details for a single committee."""
+
     model = Committee
     template_name = "committees/detail.html"
 
     def get_object(self, queryset=None):
+        """Return the committee instance for the view."""
         committee = super().get_object(queryset)
         logger.debug("Retrieved committee detail for %s", committee)
         return committee

--- a/news/admin.py
+++ b/news/admin.py
@@ -1,3 +1,5 @@
+"""Admin configuration for the news application."""
+
 from django.contrib import admin
 from django.utils.translation import gettext_lazy as _
 
@@ -5,6 +7,8 @@ from .models import Post
 
 
 class PostAdmin(admin.ModelAdmin):
+    """Admin interface definition for :class:`~news.models.Post`."""
+
     list_display = ("title", "created_at")
     list_filter = ("created_at", "updated_at")
     search_fields = ("title", "content")

--- a/news/apps.py
+++ b/news/apps.py
@@ -1,8 +1,12 @@
+"""Configuration for the news application."""
+
 from django.apps import AppConfig
 from django.utils.translation import gettext_lazy as _
 
 
 class NewsConfig(AppConfig):
+    """Application configuration for the news app."""
+
     default_auto_field = "django.db.models.BigAutoField"
     name = "news"
     verbose_name = _("News")

--- a/news/models.py
+++ b/news/models.py
@@ -1,3 +1,5 @@
+"""Database models for the news application."""
+
 from django.db import models
 from django.utils import timezone
 from django.urls import reverse
@@ -8,7 +10,11 @@ from utils.upload_paths import hashed_upload_path
 
 
 class Post(models.Model):
+    """Model representing a news post."""
+
     class Meta:
+        """Metadata for the :class:`Post` model."""
+
         verbose_name = _("Post")
         verbose_name_plural = _("News")
         ordering = ["-created_at"]
@@ -35,12 +41,15 @@ class Post(models.Model):
     updated_at = models.DateTimeField(_("updated at"), auto_now=True)
 
     def save(self, *args, **kwargs):
+        """Generate a slug from the title on first save."""
         if not self.slug:
             self.slug = slugify(self.title)
         super().save(*args, **kwargs)
 
     def get_absolute_url(self):
+        """Return the URL for the post detail page."""
         return reverse("news:detail", args=[self.slug])
 
     def __str__(self):
+        """Return the string representation of the post."""
         return self.title

--- a/news/urls.py
+++ b/news/urls.py
@@ -1,3 +1,5 @@
+"""URL configuration for the news application."""
+
 from django.urls import path
 
 from . import views

--- a/news/views.py
+++ b/news/views.py
@@ -1,3 +1,5 @@
+"""Views for the news application."""
+
 import logging
 from django.views.generic import ListView, DetailView, base, TemplateView
 
@@ -8,28 +10,38 @@ logger = logging.getLogger(__name__)
 
 
 class HomePageView(TemplateView):
+    """Render the site's home page."""
+
     template_name = "home.html"
 
 
 class IndexView(ListView):
+    """Display a list of the latest news posts."""
+
     template_name = "news/index.html"
     context_object_name = "latest_posts_list"
 
     def get_queryset(self):
+        """Return the five most recent posts."""
         logger.debug("Fetching latest posts for index view")
         return Post.objects.all()[:5]
 
 
 class DetailView(DetailView):
+    """Display details for a single news post."""
+
     model = Post
     template_name = "news/detail.html"
 
 
 class NewsArchiveView(base.TemplateView):
+    """Render an archive of news posts grouped by date."""
+
     template_name = "news/archive.html"
     context_object_name = "grouped_news"
 
     def get_queryset(self):
+        """Return posts optionally filtered by committee slug."""
         # Filter posts by committee if a query parameter is provided
         queryset = Post.objects.all()
         committee_slug = self.request.GET.get("committee")
@@ -41,6 +53,7 @@ class NewsArchiveView(base.TemplateView):
         return queryset
 
     def get_context_data(self, **kwargs):
+        """Build the context with grouped news and committees."""
         context = super().get_context_data(**kwargs)
         queryset = self.get_queryset()
 


### PR DESCRIPTION
## Summary
- Document admin modules for activities, committees, and news apps
- Add module, class, and helper docstrings to activities models
- Provide comprehensive docstrings for activity, committee, and news views

## Testing
- `pylint --disable=all --enable=C0114,C0115,C0116 --ignore=migrations,tests activities committees news`
- `pytest` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68988a60b3bc832fbaab50205c34c3fd