### PR TITLE
Run pylint on PRs with minimum score

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,6 +1,8 @@
 name: Pylint
 
-on: [push]
+on:
+  pull_request:
+    branches: [main]
 
 jobs:
   build:
@@ -20,4 +22,4 @@ jobs:
         pip install -r requirements.txt
     - name: Analysing the code with pylint
       run: |
-        pylint --rcfile .pylintrc .
+        pylint --rcfile .pylintrc --fail-under=8.01 .


### PR DESCRIPTION
## Summary
- run pylint on pull requests to main
- fail workflow when pylint score is 8.0 or lower

## Testing
- `pylint --rcfile .pylintrc manage.py`

------
https://chatgpt.com/codex/tasks/task_e_689896776a18832f8b703f1e124d1534