### PR TITLE
Disable caching in development

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -133,17 +133,27 @@ DATABASES = {
 
 
 # Caching
-# https://docs.djangoproject.com/en/5.2/topics/cache/#redis
-CACHES = {
-    "default": {
-        "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": os.getenv("REDIS_URL", "redis://127.0.0.1:6379/1"),
-        "OPTIONS": {
-            "CLIENT_CLASS": "django_redis.client.DefaultClient",
-            "IGNORE_EXCEPTIONS": True,
-        },
+# Disable caching in development to ensure controllers always receive
+# requests. This prevents the cache from serving responses when DEBUG is
+# enabled, avoiding confusion during local development. In other
+# environments, Redis is used as the cache backend.
+if DEBUG:
+    CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+        }
     }
-}
+else:
+    CACHES = {
+        "default": {
+            "BACKEND": "django_redis.cache.RedisCache",
+            "LOCATION": os.getenv("REDIS_URL", "redis://127.0.0.1:6379/1"),
+            "OPTIONS": {
+                "CLIENT_CLASS": "django_redis.client.DefaultClient",
+                "IGNORE_EXCEPTIONS": True,
+            },
+        }
+    }
 
 
 # Password validation


### PR DESCRIPTION
## Summary
- Avoid caching responses while developing by using DummyCache
- Keep Redis cache configuration for other environments

## Testing
- `pytest config/tests/test_settings.py::SettingsTest::test_cache_configuration -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4c2198658832fb08ff22793cd63f2